### PR TITLE
Add missing headers

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -76,8 +76,8 @@
   {{ end }}
 
   <!-- IndieAuth -->
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
+  <link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
+  <link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
 
   <!-- Micropub/sub -->
   <link rel="micropub" href="https://micro.blog/micropub" />

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -74,6 +74,20 @@
   {{ template "_internal/twitter_cards.html" . }}
   <!---->
   {{ end }}
+
+  <!-- IndieAuth -->
+	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
+	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
+
+  <!-- Micropub/sub -->
+  <link rel="micropub" href="https://micro.blog/micropub" />
+  <link rel="microsub" href="https://micro.blog/microsub" />
+
+  <!-- WebMention -->
+  <link rel="webmention" href="https://micro.blog/webmention" />
+  
+  <!-- Subscribe -->
+  <link rel="subscribe" href="https://micro.blog/users/follow" />
   
   {{ partial "microblog_head.html" . }}
 </head>


### PR DESCRIPTION
This commit adds missing `link` entries used by MarsEdit (and other apps) to perform login/token/micropub calls. Without these, MarsEdit can't automatically configure the blog when this theme is used.

These entries are ^C^V [from marfa](https://github.com/microdotblog/theme-marfa/blob/master/layouts/partials/head.html).