### PR TITLE
Add EditURI so that MarsEdit can detect and configure  the blog

### DIFF
--- a/layouts/partials/microblog_head.html
+++ b/layouts/partials/microblog_head.html
@@ -15,6 +15,7 @@
 <link rel="microsub" href="https://micro.blog/microsub" />
 <link rel="webmention" href="https://micro.blog/webmention" />
 <link rel="subscribe" href="https://micro.blog/users/follow" />
+<link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
 
 {{ range .Site.Params.plugins_css }}
 	<link rel="stylesheet" href="{{ . }}" />


### PR DESCRIPTION
Without this, MarsEdit (and other clients) cannot locate the information needed to configure the blog.